### PR TITLE
error message tweaks and format

### DIFF
--- a/src/asserts/actionUtils.js
+++ b/src/asserts/actionUtils.js
@@ -36,7 +36,7 @@ function unrollActions(initialState, expectedActions) {
 function notDispatchedError(dispatchedActions, expectedActions, expectedAction) {
   return new Error(
     `Expected action ${JSON.stringify(expectedAction)} was not dispatched.\n` +
-    `Expected dispatched actions: ${JSON.stringify(expectedActions)}` +
+    `Expected dispatched actions: ${JSON.stringify(expectedActions)}\n` +
     `Actual dispatched actions: ${JSON.stringify(dispatchedActions)}`
   );
 }

--- a/src/asserts/toDispatchActionsWithState.js
+++ b/src/asserts/toDispatchActionsWithState.js
@@ -4,7 +4,7 @@ import { getDispatchedActions, unrollActions, assertDispatchedActions } from './
 function toDispatchActionsWithState(initialState, actionUnderTest, expectedActions, done, fail) {
   if (!isFunction(actionUnderTest) && !isObject(actionUnderTest)) {
     throw new Error(
-      'The "actualAction" argument must be a function or object'
+      'The "actualAction" argument must be a function or an object'
     );
   }
 
@@ -13,7 +13,7 @@ function toDispatchActionsWithState(initialState, actionUnderTest, expectedActio
       !Array.isArray(expectedActions)) {
     throw new Error(
       'The "expectedActions" argument must be ' +
-      'an action creator function or an action object or an array of them'
+      'an action creator function, an action object, or an array of them'
     );
   }
 


### PR DESCRIPTION
- `\n` when logging expectedActions and actualActions
- misc format

I've been working on testing some redux stuff over the last few days and I've been pretty pleased with this library. Integrating it with karma, jasmine, and expect.

